### PR TITLE
Fix Google books API call should be capitalized printType

### DIFF
--- a/mediahandler/types/audiobooks.py
+++ b/mediahandler/types/audiobooks.py
@@ -73,7 +73,7 @@ def get_book_info(api_key, query):
     request = service.volumes().list(
         q=query,
         orderBy="relevance",
-        printType="books",
+        printType="BOOKS",
         maxResults=5
     )
 


### PR DESCRIPTION
Google books API call should be capitalized printType="BOOKS." Currently fails with "books." #1